### PR TITLE
Change from ocaml-vdom to vdom package.

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -15,7 +15,7 @@ jobs:
         uses: avsm/setup-ocaml@v1
 
       - name: Install Opam packages
-        run: opam install menhir ocaml-vdom ocamlformat=0.24.1
+        run: opam install menhir vdom ocamlformat=0.24.1
 
       - name: Build
         run: opam exec -- make release

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Do you, like me, test theoretical programming language concepts by building your
 
 Install dependencies by
 
-    opam install menhir ocaml-vdom ocamlformat
+    opam install menhir vdom ocamlformat
 
 and build Millet by running (requires OCaml >= 4.14.0)
 

--- a/src/05-backends/sig/web/dune
+++ b/src/05-backends/sig/web/dune
@@ -1,3 +1,3 @@
 (library
  (name webBackend)
- (libraries ocaml-vdom backend))
+ (libraries vdom backend))


### PR DESCRIPTION
ocaml-vdom is now named vdom and ocaml-vdom is marked as a transition package (https://ocaml.org/p/ocaml-vdom/latest). It is recommended to use the vdom package instead.

This pull request replaces ocaml-vdom with vdom in dune configuration, github pages configuration, and in the readme file.